### PR TITLE
fix loginctl list-sessions parsing

### DIFF
--- a/wayland-session
+++ b/wayland-session
@@ -506,7 +506,7 @@ get_session_by_vt() {
 	local VT="$1"
 	if [ -n "$VT" ]
 	then
-		for SESSION in $(loginctl list-sessions --no-legend | tr -s ' ' | cut -d ' ' -f 1)
+		for SESSION in $(loginctl list-sessions --no-legend | sed 's/^[[:space:]]*//; s/[[:space:]].*$//')
 		do
 			if [ \
 			  "$(loginctl show-session ${SESSION} --property Name --value)" = "${USER}" \


### PR DESCRIPTION
right-aligned column from list-sessions command output can break parsing with tr and cut alone. e.g.:

```
$ loginctl list-sessions --no-legend
  1 1000 foo seat0 tty1
464 1000 foo seat0 tty2
$ loginctl list-sessions --no-legend | tr -s " " | cut -d " " -f 1

464
$ loginctl list-sessions --no-legend | sed 's/^[[:space:]]*//; s/[[:space:]].*$//'
1
464
```