### PR TITLE
fix: pyright can't find other files from the uwsm module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,4 @@
 [tool.pyright]
 pythonVersion = "3.7"
 pythonPlatform = "Linux"
-executionEnvironments = [
-  { root = "uwsm", extraPaths = [ "build/uwsm-generated" ] },
-]
+extraPaths = [ "build/uwsm-generated" ]


### PR DESCRIPTION
given this code:
```
from uwsm.dbus import ...
```
pyright/pylance wouldn't be able to resolve the import because it would look for a `uwsm` module within `uwsm/`.