### PR TITLE
Bump Python version requirement

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,10 @@ project(
 
 PYTHON = import('python')
 PYTHON_PROG = PYTHON.find_installation('python3')
+PYTHON_VERSION = PYTHON_PROG.language_version()
+if not PYTHON_VERSION.version_compare('>=3.10')
+  error('python version >=3.10 required, found: @0@'.format(PYTHON_VERSION))
+endif
 
 PKG_DATA_DIR = join_paths(
   get_option('prefix'),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.pyright]
-pythonVersion = "3.7"
+pythonVersion = "3.10"
 pythonPlatform = "Linux"
 extraPaths = [ "build/uwsm-generated" ]


### PR DESCRIPTION
The code currently uses features that aren't compatible with older python versions.
Here's a non-exhaustive list of things pylance reports:

- (3.8) shlex.join: https://docs.python.org/3.8/library/shlex.html#shlex.join
- (3.9) argparse `exit_on_error` attr: https://docs.python.org/3.9/library/argparse.html?highlight=exit_on_error#argumentparser-objects
- (3.9) str.removeprefix: https://docs.python.org/3.9/library/stdtypes.html#str.removeprefix
- (3.9) dict union operator: https://peps.python.org/pep-0584/
- (3.10) typing union type expression: https://docs.python.org/3.10/library/typing.html#typing.Union

This version bump means officially dropping support for older debian/ubuntu LTS releases.
Ubuntu 22.04 (jammy jellyfish) ships Python 3.10: https://discourse.ubuntu.com/t/jammy-jellyfish-release-notes/24668
Debian 12 (bookworm) ships Python 3.11: https://packages.debian.org/bookworm/python3