### PR TITLE
fix: allow unrecognized PrefersNonDefaultGPU key

### DIFF
--- a/uwsm/main.py
+++ b/uwsm/main.py
@@ -336,6 +336,7 @@ def check_entry_basic(entry, entry_action=None):
             # New keys in spec not yet known by pyxdg
             "Invalid key: DBusActivatable",
             "Invalid key: SingleMainWindow",
+            "Invalid key: PrefersNonDefaultGPU",
         ]:
             continue
         errors.add(error)


### PR DESCRIPTION
I can't launch Steam otherwise.

```ini
[Desktop Entry]
Name=Steam (Runtime)
Comment=Application for managing and playing games on Steam
Exec=/usr/bin/steam-runtime %U
Icon=steam
Terminal=false
Type=Application
Categories=Network;FileTransfer;Game;
MimeType=x-scheme-handler/steam;x-scheme-handler/steamlink;
Actions=Store;Community;Library;Servers;Screenshots;News;Settings;BigPicture;Friends;
PrefersNonDefaultGPU=true
X-KDE-RunOnDiscreteGpu=true
```