### PR TITLE
fix: install Hyprland plugin as a symlink

### DIFF
--- a/uwsm-plugins/meson.build
+++ b/uwsm-plugins/meson.build
@@ -8,5 +8,6 @@ uwsm_plugins = [
 
 install_data(
   uwsm_plugins,
+  follow_symlinks: false,
   install_dir: PKG_DATA_DIR / 'plugins',
 )


### PR DESCRIPTION
The Hyprland.sh symlink gives this warning:

```
$ meson install -C build --dry-run
ninja: Entering directory `/home/peelz/code/git/uwsm/build'
ninja: no work to do.
Installing /home/peelz/code/git/uwsm/build/uwsm/uwsm to /usr/bin
Installing /home/peelz/code/git/uwsm/uwsm/__init__.py to /usr/share/uwsm/modules/uwsm
Installing /home/peelz/code/git/uwsm/uwsm/main.py to /usr/share/uwsm/modules/uwsm
Installing /home/peelz/code/git/uwsm/build/uwsm/params.py to /usr/share/uwsm/modules/uwsm
Installing /home/peelz/code/git/uwsm/uwsm-plugins/labwc.sh to /usr/share/uwsm/plugins
Installing /home/peelz/code/git/uwsm/uwsm-plugins/wayfire.sh to /usr/share/uwsm/plugins
Installing /home/peelz/code/git/uwsm/uwsm-plugins/sway.sh to /usr/share/uwsm/plugins
Installing /home/peelz/code/git/uwsm/uwsm-plugins/hyprland.sh to /usr/share/uwsm/plugins
Installing /home/peelz/code/git/uwsm/uwsm-plugins/Hyprland.sh to /usr/share/uwsm/plugins
Warning: trying to copy a symlink that points to a file. This currently copies
the file by default, but will be changed in a future version of Meson to copy
the link instead.  Set follow_symlinks to true to preserve current behavior, or
false to copy the link.
Installing /home/peelz/code/git/uwsm/example-units/cliphist.desktop to /usr/share/doc/uwsm/example-units
Installing /home/peelz/code/git/uwsm/example-units/cliphist.service to /usr/share/doc/uwsm/example-units
Installing /home/peelz/code/git/uwsm/example-units/kanshi.desktop to /usr/share/doc/uwsm/example-units
Installing /home/peelz/code/git/uwsm/example-units/kanshi.service to /usr/share/doc/uwsm/example-units
Installing /home/peelz/code/git/uwsm/example-units/waybar.desktop to /usr/share/doc/uwsm/example-units
Installing /home/peelz/code/git/uwsm/example-units/waybar.service to /usr/share/doc/uwsm/example-units
Installing /home/peelz/code/git/uwsm/README.md to /usr/share/doc/uwsm
Installing /home/peelz/code/git/uwsm/LICENSE to /usr/share/licenses/uwsm
```