### PR TITLE
README.md: recommend systemd-cat

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ trim_trailing_whitespace = true
 [*.py]
 indent_style = space
 indent_size = 4
+
+[*.scd]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ To launch automatically after login on virtual console 1, if systemd is at
 
 ```
 if uwsm check may-start && uwsm select; then
-	exec systemd-cat -t uwsm-start uwsm start default
+	exec systemd-cat -t uwsm_start uwsm start default
 fi
 ```
 
@@ -461,8 +461,8 @@ otherwise lead to nasty loops.
 `wayland-sessions`. At this point one can cancel and continue to the normal
 login shell.
 
-`systemd-cat -t uwsm-start […]` runs the command given to it with its stdout
-connected to the systemd journal, tagged with identifier `uwsm-start`.
+`systemd-cat -t uwsm_start […]` runs the command given to it with its stdout
+and stderr connected to the systemd journal, tagged with identifier `uwsm_start`.
 
 `start default` launches the previously selected default compositor.
 

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ To launch automatically after login on virtual console 1, if systemd is at
 
 ```
 if uwsm check may-start && uwsm select; then
-	exec uwsm start default
+	exec systemd-cat -t uwsm-start uwsm start default
 fi
 ```
 
@@ -461,10 +461,13 @@ otherwise lead to nasty loops.
 `wayland-sessions`. At this point one can cancel and continue to the normal
 login shell.
 
+`systemd-cat -t uwsm-start […]` runs the command given to it with its stdout
+connected to the systemd journal, tagged with identifier `uwsm-start`.
+
 `start default` launches the previously selected default compositor.
 
-`exec` in shell profile causes `uwsm` to replace login shell, binding it to
-user's login session.
+`exec` in shell profile causes `uwsm` (via `systemd-cat`) to replace login shell,
+binding it to user's login session.
 
 #### From a display manager
 

--- a/man/uwsm.1.scd
+++ b/man/uwsm.1.scd
@@ -388,7 +388,7 @@ when logged in on VT 1:
 
 ```
 	if uwsm may-start && uwsm select; then
-		exec uwsm start default
+		exec systemd-cat -t uwsm-start uwsm start default
 	fi
 ```
 
@@ -396,15 +396,18 @@ This just starts a specific compositor depending on foreground VT:
 
 ```
 	if uwsm may-start 1; then
-		exec uwsm start sway.desktop
+		exec systemd-cat -t uwsm-start uwsm start sway.desktop
 	elif uwsm may-start 2; then
-		exec uwsm start labwc.desktop
+		exec systemd-cat -t uwsm-start uwsm start labwc.desktop
 	fi
 ```
 
 Using "*uwsm may-start*" as a condition is *essential*, not only to prevent
 accidental startup attempts where they are not expected, but also since startup
 involves sourcing shell profile, which might lead to nasty loops.
+
+*systemd-cat -t uwsm-start* runs the command given to it with its stdout
+connected to the systemd journal, tagged with identifier "uwsm-start".
 
 *exec* allows uwsm to replace login shell in order to properly bind to user
 session and handle session termination.

--- a/man/uwsm.1.scd
+++ b/man/uwsm.1.scd
@@ -388,7 +388,7 @@ when logged in on VT 1:
 
 ```
 	if uwsm may-start && uwsm select; then
-		exec systemd-cat -t uwsm-start uwsm start default
+		exec systemd-cat -t uwsm_start uwsm start default
 	fi
 ```
 
@@ -396,9 +396,9 @@ This just starts a specific compositor depending on foreground VT:
 
 ```
 	if uwsm may-start 1; then
-		exec systemd-cat -t uwsm-start uwsm start sway.desktop
+		exec systemd-cat -t uwsm_start uwsm start sway.desktop
 	elif uwsm may-start 2; then
-		exec systemd-cat -t uwsm-start uwsm start labwc.desktop
+		exec systemd-cat -t uwsm_start uwsm start labwc.desktop
 	fi
 ```
 
@@ -406,8 +406,9 @@ Using "*uwsm may-start*" as a condition is *essential*, not only to prevent
 accidental startup attempts where they are not expected, but also since startup
 involves sourcing shell profile, which might lead to nasty loops.
 
-*systemd-cat -t uwsm-start* runs the command given to it with its stdout
-connected to the systemd journal, tagged with identifier "uwsm-start".
+"*systemd-cat -t uwsm-start*" runs the command given to it with its stdout
+and stderr connected to the systemd journal, tagged with identifier "uwsm_start".
+See _systemd-cat_(1) for more options.
 
 *exec* allows uwsm to replace login shell in order to properly bind to user
 session and handle session termination.
@@ -442,4 +443,4 @@ requested arguments inside the entry without any side effects.
 
 # SEE ALSO
 
-*uwsm-plugins*(3), *systemd-run*(1), *systemd.special*(7)
+*uwsm-plugins*(3), *systemd-run*(1), *systemd-cat*(1), *systemd.special*(7)


### PR DESCRIPTION
Add systemd-cat to the suggested shell profile integration.

I've set it up like that myself and am finding it useful to better see what uwsm is doing (particularly as I'm currently troubleshooting it, but also generally it's nice to see all its output).