### PR TITLE
python: add shebang

### DIFF
--- a/uwsm/dbus.py
+++ b/uwsm/dbus.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import dbus
 
 

--- a/uwsm/main.py
+++ b/uwsm/main.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """
 # Universal Wayland Desktop Session Manager
 https://github.com/Vladimir-csp/uwsm


### PR DESCRIPTION
Is there a reason we are not adding these here?

We won't have to wrap the nix package with `python3` after this, just having it in the environment/lib dir would be enough.