### PR TITLE
fix(fumon): use absolute path for sh

### DIFF
--- a/scripts/fumon.service
+++ b/scripts/fumon.service
@@ -6,7 +6,7 @@ After=graphical-session.target
 
 [Service]
 Type=exec
-ExecCondition=sh -c "command -v notify-send > /dev/null"
+ExecCondition=/bin/sh -c "command -v notify-send > /dev/null"
 ExecStart=fumon
 Restart=on-failure
 Slice=background-graphical.slice


### PR DESCRIPTION
Details in the commit message
TLDR: Doesn't work on nixos without absolute path

Not sure if this qualifies as a breaking change or not :/
