### PR TITLE
README: recommend NixOS users to use the relevant NixOS options

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,10 +259,10 @@ https://aur.archlinux.org/packages/uwsm
 </details>
 
 <details><summary>
-NixOS package.
+NixOS options.
 </summary>
 
-https://github.com/NixOS/nixpkgs/tree/master/pkgs/by-name/uw/uwsm/package.nix
+Enable it using `programs.uwsm.enable` and configure available compositors using `programs.uwsm.waylandCompositors`. Please see the options' descriptions for more information.
 
 </details>
 


### PR DESCRIPTION
The package itself will hardly do anything for a NixOS user as they will want to use the provided NixOS options to integrate uwsm into their configuration.

This gets them started by pointing them to the NixOS options which they need to configure in order to use uwsm.