### PR TITLE
Code cleanups

### DIFF
--- a/uwsm/dbus.py
+++ b/uwsm/dbus.py
@@ -1,5 +1,4 @@
 import dbus
-from uwsm.misc import print_debug
 
 
 class DbusInteractions:
@@ -8,7 +7,6 @@ class DbusInteractions:
     def __init__(self, dbus_level: str):
         "Takes dbus_level as 'system' or 'session'"
         if dbus_level in ["system", "session"]:
-            print_debug("initiate dbus interaction", dbus_level)
             self.dbus_level = dbus_level
             self.dbus_objects = {}
             if "bus" not in self.dbus_objects:

--- a/uwsm/main.py
+++ b/uwsm/main.py
@@ -1962,14 +1962,14 @@ class Args:
             action="store_true",
             dest="use_session_slice",
             default=use_session_slice,
-            help=f"Launch compositor in session.slice{' (already preset by UWSM_USE_SESSION_SLICE env var)' if use_session_slice == True else ''}.",
+            help=f"Launch compositor in session.slice{' (already preset by UWSM_USE_SESSION_SLICE env var)' if use_session_slice else ''}.",
         )
         parsers["start_slice"].add_argument(
             "-A",
             action="store_false",
             dest="use_session_slice",
             default=use_session_slice,
-            help=f"Launch compositor in app.slice{' (already preset by UWSM_USE_SESSION_SLICE env var)' if use_session_slice == False else ' (default)' if use_session_slice is None else ''}.",
+            help=f"Launch compositor in app.slice{' (already preset by UWSM_USE_SESSION_SLICE env var)' if not use_session_slice else ' (default)' if use_session_slice is None else ''}.",
         )
         parsers["start"].add_argument(
             "-F",
@@ -2862,7 +2862,7 @@ def prepare_env():
 
     sh_path = which("sh")
     if not sh_path:
-        print_error(f'"sh" is not in PATH!')
+        print_error('"sh" is not in PATH!')
         sys.exit(1)
 
     sprc = subprocess.run(
@@ -3067,7 +3067,7 @@ def gen_entry_args(entry, args, entry_action=None):
             print_debug(f'replaced with "{new_arg}", appended: {entry_args}')
 
         elif re.search(r"%[DdNnvm]", entry_arg):
-            print_debug(f"dropped as deprecated")
+            print_debug("dropped as deprecated")
 
         elif "%f" in entry_arg:
             if encountered_fu:
@@ -3161,9 +3161,9 @@ def gen_entry_args(entry, args, entry_action=None):
                 entry_args.extend(["--icon", arg])
                 print_debug(f'replaced with "--icon", "{arg}", {entry_args}')
             else:
-                print_debug(f"popped")
+                print_debug("popped")
         else:
-            print_debug(f"unchanged")
+            print_debug("unchanged")
             entry_args.append(entry_arg)
 
     print_debug("entry_cmd, entry_args post:", entry_cmd, entry_args)
@@ -3232,7 +3232,7 @@ def find_terminal_entry():
                         # only valid entry.desktop[:action] lines are of interest
                         try:
                             arg = MainArg(line)
-                        except:
+                        except Exception:
                             continue
                         if not arg.entry_id or arg.path:
                             continue
@@ -3899,7 +3899,7 @@ def fill_comp_globals():
         main_arg = MainArg(Args.parsed.wm_id)
         # Should not be a path
         if main_arg.path is not None:
-            raise ValueError(f"Aux Compositor ID argument can not be a path")
+            raise ValueError("Aux Compositor ID argument can not be a path")
         # If raw command line is given with non-empty first arg, parse it, replacing main_arg
         if Args.parsed.wm_cmdline and Args.parsed.wm_cmdline[0]:
             main_arg = MainArg(Args.parsed.wm_cmdline[0])
@@ -4864,7 +4864,7 @@ def main():
                         settle_time = os.getenv("UWSM_WAIT_VARNAMES_SETTLETIME", "0.2")
                         try:
                             settle_time = float(settle_time)
-                        except:
+                        except Exception:
                             print_warning(
                                 f'"UWSM_WAIT_VARNAMES_SETTLETIME" contains invalid value "{settle_time}", using "0.2"'
                             )
@@ -4943,7 +4943,7 @@ def main():
                 settle_time = os.getenv("UWSM_WAIT_VARNAMES_SETTLETIME", "0.2")
                 try:
                     settle_time = float(settle_time)
-                except:
+                except Exception:
                     print_warning(
                         f'"UWSM_WAIT_VARNAMES_SETTLETIME" contains invalid value "{settle_time}", using "0.2"'
                     )

--- a/uwsm/misc.py
+++ b/uwsm/misc.py
@@ -6,6 +6,8 @@ import random
 import traceback
 from typing import List
 
+from uwsm.dbus import DbusInteractions
+
 
 class Styles:
     "Terminal control characters for color and style"


### PR DESCRIPTION
- a4b020a4ac669bc92b6c228e0d2b086a8fd07d22 addresses some minor issues I found via the ruff linter.
- 144974554eb7e30f2cebd92c549c7de3afed62f8 addresses a circular dependency I noticed between the `uwsm.misc` and `uwsm.dbus` modules. This didn't seem to cause a problem in practice, but doesn't seem like a good idea. The price for fixing it is removal of a `print_debug()` statement in `DbusInteractions.__init__()`. If this is not acceptable, we can look for alternative solutions.