### PR TITLE
fix new import path for xdg to xdg_base_dirs

### DIFF
--- a/uwsm/meson.build
+++ b/uwsm/meson.build
@@ -10,9 +10,10 @@ has_system_xdg = \
   run_command(
     PYTHON_PROG,
     '-BIc',
-    'import xdg',
+    'import xdg_base_dirs',
     check: false,
   ).returncode() == 0
+  # python3 -BIc 'import xdg_base_dirs'
 
 if not has_system_dbus
   error('python dbus module not found')


### PR DESCRIPTION
original project: https://pypi.org/project/xdg/
(see the desc)
new project: https://pypi.org/project/xdg-base-dirs/
(imported as xdg_base_dirs)
I think most distros are pointing xdg pypi package to the new one xdg-base-dirs (atleast for system controlled dist/venv meaning that builds on distros that have updated to this have broken runs of builds)
