### PR TITLE
fix: Use monotonic clock for waitenv timeout

### DIFF
--- a/uwsm/main.py
+++ b/uwsm/main.py
@@ -4332,7 +4332,7 @@ def waitenv(varnames: List[str] = None, timeout=10, step=0.5, end_buffer=3):
 
     bus_session = DbusInteractions("session")
 
-    start_ts = time.time()
+    start_ts = time.monotonic()
     warned = False
     for attempt in range(1, int(timeout // step + 1)):
         aenv_varnames_set = set(bus_session.get_systemd_vars().keys())
@@ -4377,7 +4377,7 @@ def waitenv(varnames: List[str] = None, timeout=10, step=0.5, end_buffer=3):
             )
 
         # timeout
-        if time.time() - start_ts > timeout:
+        if time.monotonic() - start_ts > timeout:
             break
         time.sleep(step)
 


### PR DESCRIPTION
Hello!

When autologin is configured, my Wayland compositor always crashes . After checking systemd log I realized that it's a race condition between UWSM's waitenv and NTP time synchronization. To support windows dual-boot I configured my hardware clock to use my local timezone, which means my machine is relying on NTP server to update the time in each boot (which leaps the time forward by a few hours) and this system clock update triggers UWSM's waitenv timeout.

When dealing with timeout it's better to use monotonic clock, which is unaffected by system clock update. This is  especially the case for program like UWSM that often runs right after boot