### PR TITLE
fix: correct spelling errors in man pages

### DIFF
--- a/man/uwsm-plugins.3.scd
+++ b/man/uwsm-plugins.3.scd
@@ -62,14 +62,14 @@ It is used as plugin id and suffix in function names.
 *source\_file*
 	sources *$1* file if exists, providing messages for log.
 
-See code inside *uwsm/main.py* for more auxillary funcions.
+See code inside *uwsm/main.py* for more auxiliary functions.
 
 ## Functions that can be added by plugins
 
 *quirks\_\_*$_{\_\_WM\_BIN\_ID\_\_}_++
 	called before env loading.
 
-These functions will be called instead of standard funcions if defined:
+These functions will be called instead of standard functions if defined:
 
 *load\_wm\_env\_\_*$_{\_\_WM\_BIN\_ID\_\_}_++
 *process\_config\_dirs\_reversed\_\_*$_{\_\_WM\_BIN\_ID\_\_}_++

--- a/man/uwsm.1.scd
+++ b/man/uwsm.1.scd
@@ -68,7 +68,7 @@ be used for distro level defaults.
 |  *UWSM_WAIT_VARNAMES*
 :  (whitespace-separated names of env vars)
 | 
-:  Variables to wait for in activation environemnt before proceeding to
+:  Variables to wait for in activation environment before proceeding to
    graphical session (in addition to *WAYLAND_DISPLAY*)
 |  *UWSM_WAIT_VARNAMES_SETTLETIME*
 :  (float value)


### PR DESCRIPTION
Fix minor typos in manpages ("auxillary", "environemnt", "funcions", etc.) found while preparing Debian packaging.