### PR TITLE
Monitor uwsm service status +more

### DIFF
--- a/man/uwsm.1.scd
+++ b/man/uwsm.1.scd
@@ -80,6 +80,11 @@ be used for distro level defaults.
 :  Default unit type for launching apps
 |  *DEBUG*
 :  Dump debug info to stderr
+|  *UWSM_WAIT_TIMEOUT*
+:  (float value)
+| 
+:  Seconds to wait for variables to appear in activation environment
+   (default: 10)
 
 # OPERATION OVERVIEW
 

--- a/scripts/meson.build
+++ b/scripts/meson.build
@@ -49,3 +49,10 @@ if get_option('uwsm-app').allowed()
     pointing_to: 'uwsm-app',
   )
 endif
+
+install_data(
+  'uwsm-status.sh',
+  rename: 'uwsm-status',
+  install_dir: get_option('bindir'), 
+  install_mode: 'rwxr-xr-x'
+)

--- a/scripts/uwsm-status.sh
+++ b/scripts/uwsm-status.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+# Monitor UWSM service statuses
+# Part of UWSM, but does not depend on it.
+# https://github.com/Vladimir-csp/uwsm
+
+set -e
+
+SELF="${0##*/}"
+REFRESH_RATE=2
+
+# Handle arguments
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -r|--refresh)
+            REFRESH_RATE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: $SELF [-r SECONDS] [-h]"
+            echo "Monitor UWSM service status"
+            echo "  -r, --refresh  Refresh rate in seconds (default: 2)"
+            echo "  -h, --help     Show this help"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Handle Ctrl+C gracefully
+trap 'echo "Exiting..."; exit 0' INT
+
+check_service() {
+    systemctl --user --no-pager status "$1" 2>/dev/null || echo "Service $1 not found"
+}
+
+while true; do
+    clear
+    echo "=== UWSM Status Monitor ==="
+    echo "Press Ctrl+C to exit"
+    echo
+    
+    echo "=== Compositor Service ==="
+    check_service "wayland-wm@*.service"
+    echo
+    
+    echo "=== Environment Service ==="
+    check_service "wayland-wm-env@*.service"
+    echo
+    
+    echo "=== Session Target ==="
+    check_service "wayland-session@*.target"
+    
+    sleep "$REFRESH_RATE"
+done

--- a/uwsm/main.py
+++ b/uwsm/main.py
@@ -4150,7 +4150,7 @@ def fill_comp_globals():
                     entry_uwsm_args.parsed.desktop_names
                 ):
                     raise ValueError(
-                        f'Entry "{CompGlobals.id}" uses {BIN_NAME} with malformed desktop names: "{entry_uwsm_args.parsed.desktop_names}"!'
+                        f'{BIN_NAME} in entry "{CompGlobals.id}" uses {BIN_NAME} with malformed desktop names: "{entry_uwsm_args.parsed.desktop_names}"!'
                     )
 
                 # parse secondary entry
@@ -4476,9 +4476,11 @@ def waitpid(pid: int):
     return
 
 
-def waitenv(varnames: List[str] = None, timeout=10, step=0.5, end_buffer=3):
-    "Waits for varnames to appear in activation environment"
-
+def waitenv(varnames: List[str] = None, timeout=None, step=0.5, end_buffer=3):
+    """Wait for variables to appear in activation environment"""
+    if timeout is None:
+        # Get timeout from env var or use default
+        timeout = float(os.getenv("UWSM_WAIT_TIMEOUT", "10"))
     if varnames is None:
         varnames = ["WAYLAND_DISPLAY"]
     else:


### PR DESCRIPTION
1. Created a monitoring script that shows formatted status of UWSM services with configurable refresh rate.
    `scripts/uwsm-status.sh`

2. Added block to `mason.build` that installs `scripts/uwsm-status.sh` unconditionally.
3. Added configurable timeout to `main.py` using the `UWSM_WAIT_TIMEOUT` env variable.
4. Added the `UWSM_WAIT_TIMEOUT` to `man/uwsm.1.scd` documentation.