### PR TITLE
fix file opening encoding to UTF-8 (was invalid UTF=8)

### DIFF
--- a/uwsm/main.py
+++ b/uwsm/main.py
@@ -1828,7 +1828,7 @@ def remove_units(only=None) -> None:
                 continue
             print_debug("checking for removal:", file_path)
             try:
-                with open(file_path, "r", encoding="UTF=8") as unit_file:
+                with open(file_path, "r", encoding="utf-8") as unit_file:
                     for line in unit_file.readlines():
                         if (only and line.strip() == mark_attr) or (
                             not only and line.strip().startswith(mark_attr)


### PR DESCRIPTION
Python silently accepts `"UTF=8"` by normalizing it to `"utf-8"`, but this is not a standard or valid encoding identifier per IANA or most tools.

This change replaces the non-standard `"UTF=8"` with the correct and widely accepted `"UTF-8"` string, and also maintains consistency with the rest of the codebase which uses `"utf-8"`.

While this did not raise an error in Python, it could lead to confusion, portability issues, or incorrect assumptions by other tools or developers.