### PR TITLE
[man] Fix table rendering by piping scdoc output through tbl

### DIFF
--- a/man/meson.build
+++ b/man/meson.build
@@ -1,6 +1,7 @@
 scdoc = dependency('scdoc', version: '>=1.9.2', native: true, required: get_option('man-pages'))
 if scdoc.found()
   scdoc_prog = find_program(scdoc.get_variable(pkgconfig: 'scdoc'), native: true)
+  tbl = find_program('tbl', native: true, required: true)
   mandir = get_option('mandir')
   man_files = [
     'uwsm.1.scd',
@@ -24,10 +25,12 @@ if scdoc.found()
       output,
       input: filename,
       output: output,
-      command: scdoc_prog,
+      command: [
+        'sh', '-c',
+        '@0@ < $1 | tbl > $2'.format(scdoc_prog.full_path()),
+        '', '@INPUT@', '@OUTPUT@'
+      ],
       install: true,
-      feed: true,
-      capture: true,
       install_dir: '@0@/man@1@'.format(mandir, section)
     )
   endforeach


### PR DESCRIPTION
## Problem

Currently, the man pages generated via `scdoc` are not passed through the `tbl` preprocessor. This could cause rendering issues for tables and triggers the following warning from `lintian` during Debian packaging:

```
groff-message: tbl preprocessor failed, or it or soelim was not run; table(s) likely not rendered (TE macro called with TW register undefined)
```
## Cause
* `scdoc` outputs man(7)-style troff source.
* If the document uses `.TS` / `.TE` macros for tables, the output **must** be piped through the `tbl` preprocessor before rendering.
* Without `tbl`, table macros are left unprocessed, potentially causing rendering issues and warnings from tools like `groff`, which is invoked by `lintian`.

## Solution

Wrap `scdoc` invocation in a shell pipeline that explicitly pipes its output through `tbl`:

```meson
command: [
  'sh', '-c',
  '@0@ < $1 | tbl > $2'.format(scdoc_prog.full_path()),
  '', '@INPUT@', '@OUTPUT@'
]
```
**There might be a better solution to do that, however thats what I came up with. Would appreciate feedback.**

Ensures that:

* Tables are rendered correctly
* `lintian` passes without warnings