### PR TITLE
add meson option for examples subdirectory

### DIFF
--- a/example-units/meson.build
+++ b/example-units/meson.build
@@ -11,4 +11,4 @@ example_files = [
   'waybar_override.conf',
 ]
 
-install_data(example_files, install_dir: PKG_DOC_DIR / 'example-units')
+install_data(example_files, install_dir: PKG_DOC_DIR / get_option('doc_examples_subdir'))

--- a/meson.options
+++ b/meson.options
@@ -4,6 +4,12 @@ option(
   description: 'documentation directory',
 )
 option(
+  'doc_examples_subdir',
+  type: 'string',
+  value: 'example-units',
+  description: 'Directory name under doc/uwsm/ for example files'
+)
+option(
   'man-pages',
   type: 'feature',
   value: 'enabled',


### PR DESCRIPTION
This PR adds a Meson option `doc_examples_subdir` to control the subdirectory name used under `PKG_DOC_DIR` for installing example files.

Currently, the files are installed to:

```

/usr/share/doc/uwsm/example-units/

```

However, [Debian Policy §12.3](https://www.debian.org/doc/debian-policy/ch-docs.html#examples) states that example files should be installed under:

```

/usr/share/doc/package/examples/

````

This option enables downstreams (like Debian) to override the subdirectory name at build time, without requiring a persistent patch to `meson.build`:

```sh
meson setup build -Ddoc_examples_subdir=examples
````

### Notes

* The default value remains `"example-units"` to preserve current behavior.
* This change is backward-compatible and has no effect unless the option is explicitly set.