### PR TITLE
Fix Python version check

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,11 +6,13 @@ project(
 )
 
 PYTHON = import('python')
-PYTHON_PROG = PYTHON.find_installation('python3')
+PYTHON_BIN_OPTION = get_option('python-bin')
+PYTHON_PROG = PYTHON.find_installation(PYTHON_BIN_OPTION)
 PYTHON_VERSION = PYTHON_PROG.language_version()
 if not PYTHON_VERSION.version_compare('>=3.10')
   error('python version >=3.10 required, found: @0@'.format(PYTHON_VERSION))
 endif
+PYTHON_BIN = PYTHON_PROG.full_path()
 
 
 PKG_DATA_DIR = join_paths(
@@ -44,11 +46,6 @@ SD_USER_DIR = join_paths(
 
 PROJECT_NAME = meson.project_name()
 PROJECT_VERSION = meson.project_version()
-
-PYTHON_BIN = get_option('python-bin')
-if PYTHON_BIN == ''
-  PYTHON_BIN = PYTHON_PROG.full_path()
-endif
 
 conf = configuration_data()
 conf.set('PROJECT_NAME', PROJECT_NAME)

--- a/meson.options
+++ b/meson.options
@@ -18,6 +18,7 @@ option(
 option(
   'python-bin',
   type: 'string',
+  value: 'python3',
   description: 'path to the python binary',
 )
 option(


### PR DESCRIPTION
Fixes the Python version check to use Python provided by the `python-bin` option. Previously, the check was checking the system Python installation unconditionally, which might be older than 3.10. That prevents UWSM from installing on stable distros even if `python-bin` points to a compatible Python version.