### PR TITLE
docs: entry example

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,7 +762,7 @@ user's login session.
 #### From a display manager
 
 To launch uwsm from a display/login manager, `uwsm` can be used inside desktop
-entries. Example `/usr/local/share/wayland-sessions/my-compositor-uwsm.desktop`:
+entries. Example `/usr/share/wayland-sessions/my-compositor-uwsm.desktop`:
 
 ```
 [Desktop Entry]

--- a/README.md
+++ b/README.md
@@ -762,7 +762,19 @@ user's login session.
 #### From a display manager
 
 To launch uwsm from a display/login manager, `uwsm` can be used inside desktop
-entries. Example `/usr/share/wayland-sessions/my-compositor-uwsm.desktop`:
+entries.
+
+By default most display/login managers read them from `/usr/share/wayland-sessions` 
+directory. You should be aware that this directory is populated with bundled
+entries from the installed compositors, so it's better to place
+custom entries in `/usr/local/share/wayland-sessions`. 
+
+If your display/login manager doesn't respect the `XDG_DATA_DIRS` environment
+variable, your session in `/usr/local/share/wayland-sessions` could be unlisted.
+In this case, add this directory to the session search path of your
+display/login manager.
+
+Example `/usr/local/share/wayland-sessions/my-compositor-uwsm.desktop`:
 
 ```
 [Desktop Entry]

--- a/README.md
+++ b/README.md
@@ -775,8 +775,7 @@ Exec=uwsm start -- my-compositor.desktop
 # or a full command line with metadata and executable
 #Exec=uwsm start -N "My compositor" -D mycompositor:mylib -C "My cool compositor" -- mywm
 
-# don't autostart (e.g. autologin) if uwsm is not installed
-# in a case of a removal or copying the entry to a new machine
+# invalidates entry if uwsm is missing
 TryExec=uwsm
 
 DesktopNames=mycompositor;mylib

--- a/README.md
+++ b/README.md
@@ -775,6 +775,10 @@ Exec=uwsm start -- my-compositor.desktop
 # or a full command line with metadata and executable
 #Exec=uwsm start -N "My compositor" -D mycompositor:mylib -C "My cool compositor" -- mywm
 
+# don't autostart (e.g. autologin) if uwsm is not installed
+# in a case of a removal or copying the entry to a new machine
+TryExec=uwsm
+
 DesktopNames=mycompositor;mylib
 Type=Application
 ```

--- a/README.md
+++ b/README.md
@@ -764,15 +764,9 @@ user's login session.
 To launch uwsm from a display/login manager, `uwsm` can be used inside desktop
 entries.
 
-By default most display/login managers read them from `/usr/share/wayland-sessions` 
-directory. You should be aware that this directory is populated with bundled
-entries from the installed compositors, so it's better to place
-custom entries in `/usr/local/share/wayland-sessions`. 
-
-If your display/login manager doesn't respect the `XDG_DATA_DIRS` environment
-variable, your session in `/usr/local/share/wayland-sessions` could be unlisted.
-In this case, add this directory to the session search path of your
-display/login manager.
+These entries are placed in `wayland-sessions` subdirectory of `XDG_DATA_DIRS`.
+Usually, if `XDG_DATA_DIRS` contains `/usr/local/share` and `/usr/share`, user
+defined entries are placed in `/usr/local/share/wayland-sessions`.
 
 Example `/usr/local/share/wayland-sessions/my-compositor-uwsm.desktop`:
 


### PR DESCRIPTION
for the first commit, i think the path is just not right? on my machine `/usr/local/share` has only one symlink to an empty `man` directory. the only directory for `wayland-sessions` on my machine is `/usr/share/wayland-sessions` (and it's the same as in the [tuigreet docs](https://github.com/apognu/tuigreet?tab=readme-ov-file#sessions), for example).

for the second commit, i saw this while making my own desktop file for the uwsm niri session and comparing it to hyprland session. it uses `TryExec`, and it seems like a good tone. i think this should be included in the example.