### PR TITLE
fix: uwsm start help

### DIFF
--- a/uwsm/main.py
+++ b/uwsm/main.py
@@ -2100,7 +2100,6 @@ class Args:
                 """
             ),
         )
-        parsers["start_slice"] = parsers["start"].add_mutually_exclusive_group()
         unit_rung_preset = False
         unit_rung_default = os.getenv("UWSM_UNIT_RUNG", None)
         if unit_rung_default in ("run", "home"):


### PR DESCRIPTION
Fixes regression caused by commit 011fd3370a4401845c4f2a673f37dd22a2968cac

Creating empty mutually exclusive group causes `ValueError` exception to be thrown.