### PR TITLE
fix: quotes in f-string for python before 3.12

### DIFF
--- a/uwsm/main.py
+++ b/uwsm/main.py
@@ -3694,7 +3694,7 @@ def app(
         final_args.extend(
             ["--property=Type=exec", "--property=ExitType=cgroup"]
             + [
-                f"--setenv={var}={os.environ.get(var, "")}"
+                f"--setenv={var}={os.environ.get(var, '')}"
                 for var in sorted(Varnames.session_specific)
                 if os.environ.get(var, "")
             ]


### PR DESCRIPTION
Use of quotes inside f-strings before Python 3.12 had limitations.