### PR TITLE
Add `StopPropagatedFrom=` to graphical slices to prevent app crash from killing the session

### DIFF
--- a/systemd/user/app-graphical.slice
+++ b/systemd/user/app-graphical.slice
@@ -5,3 +5,4 @@ PartOf=graphical-session.target
 After=graphical-session.target
 Conflicts=wayland-session-shutdown.target
 Before=wayland-session-shutdown.target
+StopPropagatedFrom=graphical-session.target

--- a/systemd/user/background-graphical.slice
+++ b/systemd/user/background-graphical.slice
@@ -5,3 +5,4 @@ PartOf=graphical-session.target
 After=graphical-session.target
 Conflicts=wayland-session-shutdown.target
 Before=wayland-session-shutdown.target
+StopPropagatedFrom=graphical-session.target

--- a/systemd/user/session-graphical.slice
+++ b/systemd/user/session-graphical.slice
@@ -5,3 +5,4 @@ PartOf=graphical-session.target
 After=graphical-session.target
 Conflicts=wayland-session-shutdown.target
 Before=wayland-session-shutdown.target
+StopPropagatedFrom=graphical-session.target


### PR DESCRIPTION
Fixes [#215]
Currently, when an application launched via `uwsm app` crashes hard enough for
systemd to stop its scope, the stop propagates upward through
`app-graphical.slice` via `PartOf=graphical-session.target`. Because
`graphical-session.target` has `StopWhenUnneeded=yes`, it then stops itself,
which kills the compositor via `BindsTo=` on `wayland-wm@.service` — taking
down the entire session even though the compositor and every other app were
perfectly healthy.
The fix is to add `StopPropagatedFrom=graphical-session.target` to all three
graphical slices. This directive tells systemd not to propagate stop signals
originating from within the slice back up to the target, breaking the reverse
cascade while leaving the intended direction fully intact: when the session
shuts down intentionally, the stop still flows down into the slice and cleans
up all apps correctly. The existing `Conflicts=wayland-session-shutdown.target`
+ `Before=wayland-session-shutdown.target` pair already handles clean teardown
ordering independently of `PartOf=`, so nothing is lost.

> **⚠️ systemd version requirement:** `StopPropagatedFrom=` was introduced in
> **systemd 256** (released October 2024). This fix has no effect and will be
> silently ignored on older versions. Distributions still shipping systemd < 256
> will need an alternative approach to address this bug. Users on affected
> systems can verify their version with `systemctl --version`.