### PR TITLE
Don't block all app launches when a uwsm-app client dies

### DIFF
--- a/uwsm/main.py
+++ b/uwsm/main.py
@@ -26,6 +26,7 @@ import textwrap
 import time
 import signal
 import stat
+import errno
 from typing import List, Callable
 from urllib import parse as urlparse
 from select import select
@@ -3858,8 +3859,20 @@ def app_daemon():
         "Takes original args_in (list), and final args_out (str), writes to output fifo"
         print_normal(f"received: {shlex.join(args_in)}\nsent: {args_out}")
         fifo_out_path = create_fifo("uwsm-app-daemon-out")
-        with open(fifo_out_path, "w", encoding="UTF-8") as fifo_out:
-            fifo_out.write(f"{args_out}\n")
+        try:
+            fd = open_fifo_write(fifo_out_path)
+        except TimeoutError:
+            print_warning(
+                f"Timed out waiting for client to read {fifo_out_path}, dropping reply"
+            )
+            return
+        with os.fdopen(fd, "w", encoding="UTF-8") as fifo_out:
+            try:
+                fifo_out.write(f"{args_out}\n")
+            except BrokenPipeError:
+                print_warning(
+                    f"Client closed {fifo_out_path} before reply was written"
+                )
 
     while True:
         # create both pipes right away and make sure they always exist
@@ -3961,6 +3974,30 @@ def app_daemon():
                 args_in, f"error {shlex.quote('Error: ' + str(caught_exception))} 1"
             )
             continue
+
+
+# Matches TIMEOUT in scripts/uwsm-app.sh
+APP_DAEMON_FIFO_TIMEOUT = 10
+
+
+def open_fifo_write(path, timeout=APP_DAEMON_FIFO_TIMEOUT):
+    """Open FIFO for writing, waiting up to timeout seconds for a reader.
+
+    Blocking open() waits forever. A client that dies after writing IN
+    would leave the daemon stuck here and block all later launches.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            fd = os.open(path, os.O_WRONLY | os.O_NONBLOCK)
+            os.set_blocking(fd, True)
+            return fd
+        except OSError as err:
+            if err.errno != errno.ENXIO:
+                raise
+            if time.monotonic() >= deadline:
+                raise TimeoutError(path)
+            time.sleep(0.05)
 
 
 def create_fifo(path):


### PR DESCRIPTION
Grok (xAI), writing with Sean.

If a `uwsm-app` client dies after writing the IN fifo and before opening OUT, every later launch fails with `Timed out trying to write to /run/user/$UID/uwsm-app-daemon-in` until the session is restarted. The daemon has already logged `sent:` but is blocked forever in `open(OUT)`.

## How

Time out that `open(OUT)` after 10s (the same budget as `uwsm-app`), drop the reply, and go back to reading IN. Idle wait on IN is unchanged.

## Where

- `uwsm/main.py` — `send_cmdline` and `open_fifo_write`

Complementary to [omacom/omarchy#9807](https://github.com/omacom/omarchy/pull/9807), which stops a systemd oneshot from killing the client mid-handshake. This recovers if any client still dies. Distinct from #209 (argparse `SystemExit` / lock held).

## Test plan

- FIFO with no reader: `open_fifo_write(..., timeout=0.3)` raises `TimeoutError` in ~0.3s
- FIFO with a reader a moment later: write succeeds
- Kill `uwsm-app` after it writes IN; `uwsm-app ping` works after the 10s drop instead of remaining wedged