### PR TITLE
fix(uwsm-app): reap pipekiller before exec/exit

### DIFF
--- a/scripts/uwsm-app.sh
+++ b/scripts/uwsm-app.sh
@@ -185,6 +185,9 @@ release_lock
 
 # kill timeout killer process and its sleep process
 kill "$KILLER_PID"
+# Reap it before exec/exit, otherwise the launched long-running app
+# inherits it as a zombie child.
+wait "$KILLER_PID" 2>/dev/null || true
 
 case "$CMDLINE" in
 pong)


### PR DESCRIPTION
## Problem

When `uwsm-app` launches a long-running application (e.g. `udiskie`), it leaves a zombie `[uwsm-app] <defunct>` process behind as a child of that application.

### Root cause

`scripts/uwsm-app.sh` forks a background `pipekiller`:

```sh
pipekiller &
KILLER_PID=$!
```

After the IPC exchange finishes, it kills the killer but never reaps it:

```sh
kill "$KILLER_PID"
```

For an app launch the script then receives a command line starting with `exec` (for example `exec systemd-run --user --scope ... -- udiskie ...`) and evaluates it. The shell process is replaced by the launched application, so the dead `pipekiller` child stays as a zombie under the new long-running process. Applications that do not install a SIGCHLD handler or call `waitpid()` on unknown children (e.g. Python-based `udiskie`) never reap it.

### Repro

Observed on Omarchy/Arch with `udiskie` launched through `uwsm-app`:

```text
PID  PPID  STAT  COMMAND
1713 1638  Sl    /usr/bin/python /usr/bin/udiskie --automount --no-notify --no-tray
1723 1713  Z     [uwsm-app] <defunct>
```

`1723` start time is one jiffy after `1713`, confirming it was the `pipekiller` backgrounded by the `uwsm-app` script that became udiskie via `exec`.

### Fix

Reap the killer before `exec`/`exit`:

```sh
kill "$KILLER_PID"
# Reap it before exec/exit, otherwise the launched long-running app
# inherits it as a zombie child.
wait "$KILLER_PID" 2>/dev/null || true
```

### Testing

- Killed the old `udiskie` instance and relaunched it through the patched `uwsm-app`.
- After the relaunch the new `udiskie` process has no zombie child.
- No zombies remain system-wide.
